### PR TITLE
Termine im machBar-Kalender

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Chaostreff-Potsdam.github.io
 Willkommen auf der Webseite vom Chaostreff Potsdam
 
-Das nächste Treffen ist am 23.05.2018 um 19 Uhr in der machBar (Friedrich-Engels-Str. 22 - freiLand - Haus 5). Sie finden turnusmäßig alle 2 Wochen mittwochs statt.
+Das die Treffen sind in der machBar (Friedrich-Engels-Str. 22 - freiLand - Haus 5). Sie finden turnusmäßig alle 2 Wochen mittwochs statt. Wann genau, steht im [Kalender der machBar][machBar-Kalender].
 
-
-[Mailingliste][join-mailing-list]
+Wenn du mitbekommen magst, wann wir uns treffen und welche Themen du mit uns vorbereiten kannst, dann kannst du der
+[Mailingliste beitreten][join-mailing-list].
 
 
 
 
 [join-mailing-list]: mailto:&#109;&#097;&#106;&#111;&#114;&#100;&#111;&#109;&#111;&#064;&#102;&#097;&#098;&#108;&#097;&#098;&#045;&#099;&#111;&#116;&#116;&#098;&#117;&#115;&#046;&#100;&#101;?subject=subscribe&#32;chaos-treff-potsdam-fablab-cottbus-de&body=subscribe&#32;chaos-treff-potsdam-fablab-cottbus-de
+[machBar-Kalender]: https://machbar-potsdam.de/?page_id=1250


### PR DESCRIPTION
Die Termine können hier über einen Link auf den machBar-Kalender eingesehen werden.