### PR TITLE
Add an Impressum

### DIFF
--- a/Impressum.md
+++ b/Impressum.md
@@ -1,0 +1,58 @@
+# Impressum
+
+Angaben gemäß § 5 TMG
+
+Chaostreff Potsdam e. V.
+freiLand, Haus 5
+Friedrich-Engels-Str. 22
+14473 Potsdam
+
+**Vertreten durch:**
+Max Muster
+
+**Kontakt:**
+Telefon: 01234-789456
+Fax: 1234-56789 lol
+E-Mail: vorstand@ ...
+
+**Registereintrag:**
+Eintragung im Registergericht: Musterstadt
+Registernummer: 12345
+
+**Umsatzsteuer-ID:**
+Umsatzsteuer-Identifikationsnummer gemäß §27a Umsatzsteuergesetz: Musterustid.
+
+**Wirtschafts-ID:**
+Musterwirtschaftsid
+
+**Aufsichtsbehörde:**
+Musteraufsicht Musterstadt
+
+**Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:**
+Max Muster
+Musterweg
+12345 Musterstadt
+
+
+Haftungsausschluss:
+
+Haftung für Inhalte
+
+Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.
+
+Haftung für Links
+
+Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+
+Urheberrecht
+
+Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
+
+Datenschutz
+
+Die Nutzung unserer Webseite ist in der Regel ohne Angabe personenbezogener Daten möglich. Soweit auf unseren Seiten personenbezogene Daten (beispielsweise Name, Anschrift oder eMail-Adressen) erhoben werden, erfolgt dies, soweit möglich, stets auf freiwilliger Basis. Diese Daten werden ohne Ihre ausdrückliche Zustimmung nicht an Dritte weitergegeben.
+Wir weisen darauf hin, dass die Datenübertragung im Internet (z.B. bei der Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.
+Der Nutzung von im Rahmen der Impressumspflicht veröffentlichten Kontaktdaten durch Dritte zur Übersendung von nicht ausdrücklich angeforderter Werbung und Informationsmaterialien wird hiermit ausdrücklich widersprochen. Die Betreiber der Seiten behalten sich ausdrücklich rechtliche Schritte im Falle der unverlangten Zusendung von Werbeinformationen, etwa durch Spam-Mails, vor.
+
+Website Impressum erstellt durch [impressum-generator.de](https://www.impressum-generator.de)von der [Kanzlei Hasselbach](https://www.kanzlei-hasselbach.de/).
+ 

--- a/Impressum.md
+++ b/Impressum.md
@@ -8,30 +8,31 @@ Friedrich-Engels-Str. 22
 14473 Potsdam
 
 **Vertreten durch:**
-Max Muster
+Christoph Sterz
 
 **Kontakt:**
-Telefon: 01234-789456
-Fax: 1234-56789 lol
-E-Mail: vorstand@ ...
+Telefon: 016Drei / Neun7096EinsEins
+E-Mail*: vorstand .ǎŧ. ccc-p @.@ org
+
+* Ersetzen Sie `.ǎŧ.` durch `@` und `@.@` durch `.` .
 
 **Registereintrag:**
-Eintragung im Registergericht: Musterstadt
-Registernummer: 12345
+Eintragung im Registergericht: Amtsgericht Potsdam
+Registernummer: VR 9098 P
 
-**Umsatzsteuer-ID:**
+<!-- **Umsatzsteuer-ID:**
 Umsatzsteuer-Identifikationsnummer gemäß §27a Umsatzsteuergesetz: Musterustid.
 
 **Wirtschafts-ID:**
-Musterwirtschaftsid
+Musterwirtschaftsid -->
 
-**Aufsichtsbehörde:**
-Musteraufsicht Musterstadt
+<!-- **Aufsichtsbehörde:**
+Musteraufsicht Musterstadt -->
 
 **Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:**
-Max Muster
-Musterweg
-12345 Musterstadt
+Christoph Sterz
+Großbeerenstraße 34
+14482 Potsdam 
 
 
 Haftungsausschluss:


### PR DESCRIPTION
Hab gesehen, dass wir noch kein Impressum hatten.
Also hab ich mal https://www.impressum-generator.de/impressum-generator/ durchgespielt.
Die Frage ist welches Vorstandsmitglied sich opfert und als Verantwortlicher eingetragen wird
(können auch mehrere sein, aber Datensparsamkeit).
Ust und anderes gedöhns weiß ich nicht ob wir das haben.

Den Abschnitt `Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV` braucht man wohl, wenn man
redaktionell tätig ist.
Dachte erst ok brauchen wir nicht, aber wir haben ja den Nerdtalk Podcast/Radio.
Laut Generator zählen wohl schon Blogs, also wahrscheinlich better safe than sorry?

https://www.bmjv.de/DE/Verbraucherportal/DigitalesTelekommunikation/Impressumspflicht/Impressumspflicht_node.html