### PR TITLE
Update Covid info-banner (once again) and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 Willkommen auf der Webseite des Chaostreff Potsdam!
 
-<div style="background: #b00; padding: 1em;">Die wöchentlichen Vor-Ort-Treffen finden derzeit, aufgrund des Coronarisikos, nur bei gutem Wetter im Freien statt. 
-
-Bei schlechtem Wetter treffen wir uns mittwochs ab 19 Uhr hier: <a href="https://meet.d.ccc-p.org/treff">https://meet.d.ccc-p.org/treff</a>
-
-Ob das wöchentliche Treffen vor Ort oder online stattfindet, wird im Laufe des Mittwochs über unsere Online-Kommunikationskanäle bekannt gegeben: <a href="#unsere-kommunikationskanäle">hier!</a></div>
+{% include covid-info.md %}
 
 Die Treffen sind in der machBar (Friedrich-Engels-Str. 22 - freiLand - Haus 5).
 Sie finden turnusmäßig jede Woche mittwochs um 19:00 Uhr (MEZ) statt. (Siehe auch im [Kalender der machBar][machBar-Kalender].)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Willkommen auf der Webseite des Chaostreff Potsdam!
 
-<div style="background: #b00; padding: 1em;">Die wöchentlichen Vor-Ort-Treffen finden derzeit aufgrund des Coronarisikos, nur bei gutem Wetter im Freien statt. 
+<div style="background: #b00; padding: 1em;">Die wöchentlichen Vor-Ort-Treffen finden derzeit, aufgrund des Coronarisikos, nur bei gutem Wetter im Freien statt. 
 
 Bei schlechtem Wetter treffen wir uns mittwochs ab 19 Uhr hier: <a href="https://meet.d.ccc-p.org/treff">https://meet.d.ccc-p.org/treff</a>
 
-Ob das wöchentliche Treffen Vor-Ort oder Online stattfindet, wird im Laufe des Mittwochs über unsere Online-Kommunikationskanäle bekannt gegeben: <a href="#unsere-kommunikationskanäle">hier!</a></div>
+Ob das wöchentliche Treffen vor Ort oder online stattfindet, wird im Laufe des Mittwochs über unsere Online-Kommunikationskanäle bekannt gegeben: <a href="#unsere-kommunikationskanäle">hier!</a></div>
 
 Die Treffen sind in der machBar (Friedrich-Engels-Str. 22 - freiLand - Haus 5).
 Sie finden turnusmäßig jede Woche mittwochs um 19:00 Uhr (MEZ) statt. (Siehe auch im [Kalender der machBar][machBar-Kalender].)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Willkommen auf der Webseite des Chaostreff Potsdam!
 
-<div style="background: #b00; padding: 1em;">Die wöchentlichen Vor-Ort-Treffen finden derzeit aufgrund des Coronarisikos nicht statt!
+<div style="background: #b00; padding: 1em;">Die wöchentlichen Vor-Ort-Treffen finden derzeit aufgrund des Coronarisikos, nur bei gutem Wetter im Freien statt. 
 
-Stattdessen treffen wir uns mittwochs ab 19 Uhr hier: <a href="https://world.ccc-p.org/">https://world.ccc-p.org</a>
+Bei schlechtem Wetter treffen wir uns mittwochs ab 19 Uhr hier: <a href="https://meet.d.ccc-p.org/treff">https://meet.d.ccc-p.org/treff</a>
 
-Weitere Online-Kommunikationskanäle bei Chaosentzug: <a href="#unsere-kommunikationskanäle">hier!</a></div>
+Ob das wöchentliche Treffen Vor-Ort oder Online stattfindet, wird im Laufe des Mittwochs über unsere Online-Kommunikationskanäle bekannt gegeben: <a href="#unsere-kommunikationskanäle">hier!</a></div>
 
 Die Treffen sind in der machBar (Friedrich-Engels-Str. 22 - freiLand - Haus 5).
 Sie finden turnusmäßig jede Woche mittwochs um 19:00 Uhr (MEZ) statt. (Siehe auch im [Kalender der machBar][machBar-Kalender].)

--- a/_data/covid-info.yml
+++ b/_data/covid-info.yml
@@ -1,0 +1,2 @@
+online: False
+meeting-url: "https://world.ccc-p.org"

--- a/_includes/covid-info.md
+++ b/_includes/covid-info.md
@@ -1,0 +1,15 @@
+{% assign online = site.data.covid-info.online %}
+{% assign url = site.data.covid-info.meeting-url %}
+
+<div style="background: #b00; padding: 1em; border-radius: 15px;">
+Die wöchentlichen Vor-Ort-Treffen finden derzeit aufgrund des Coronarisikos {% if online %} nicht {% else %} nur bei gutem Wetter im Freien {% endif %} statt!
+
+{% if online %} Stattdessen {% else %} Bei schlechtem Wetter {% endif %} treffen wir uns mittwochs ab 19 Uhr hier: <a href="{{ url }}">{{ url }}</a>.
+
+{% if online %}
+Weitere Online-Kommunikationskanäle bei Chaosentzug:
+{% else %}
+Ob das wöchentliche Treffen vor Ort oder online stattfindet, wird im Laufe des Mittwochs über unsere Online-Kommunikationskanäle bekannt gegeben:
+{% endif %}
+<a href="#unsere-kommunikationskanäle">hier!</a>
+</div>


### PR DESCRIPTION
This updates the Covid-Info to "IRL mode".
The message can be changed to "online mode" by setting the `online` variable in `_data/covid-info.yml`.
Also URL to the online meeting platform can be configured.